### PR TITLE
Add full DSL grammar

### DIFF
--- a/src/lyrics.pest
+++ b/src/lyrics.pest
@@ -1,11 +1,46 @@
-song = { SOI ~ metadata ~ section+ ~ EOI }
-metadata = { (meta_key ~ ":" ~ value ~ NEWLINE)+ }
-meta_key = { "title" | "artist" }
-value = _{ quoted_string | ASCII_ALPHANUMERIC+ }
-section = _{ verse | chorus }
-verse = { "VERSE" ~ section_number? ~ NEWLINE ~ line+ }
-chorus = { "CHORUS" ~ section_number? ~ NEWLINE ~ line+ }
-section_number = { "[" ~ ASCII_DIGIT+ ~ "]" }
-line = { (!NEWLINE ~ ANY)+ ~ NEWLINE }
-quoted_string = _{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
-NEWLINE = _{ "\n" }
+// Full Lyrics DSL grammar as defined in README.md
+
+song            = { SOI ~ metadata ~ sections ~ EOI }
+
+metadata        = { meta_entry+ }
+meta_entry      = { meta_key ~ ":" ~ meta_value ~ NEWLINE }
+meta_key        = { "title" | "artist" | "tempo" | "key" | "time_sig" | "genre" | "lang" | "writers" | "duration" }
+meta_value      = { quoted_string | number | identifier }
+
+sections        = { section+ }
+section         = { verse | chorus | bridge | pre_chorus | outro | intro }
+
+verse           = { "VERSE" ~ section_number? ~ section_attrs? ~ NEWLINE ~ lines }
+chorus          = { "CHORUS" ~ section_number? ~ section_attrs? ~ NEWLINE ~ lines }
+bridge          = { "BRIDGE" ~ section_attrs? ~ NEWLINE ~ lines }
+pre_chorus      = { "PRE-CHORUS" ~ section_attrs? ~ NEWLINE ~ lines }
+outro           = { "OUTRO" ~ section_attrs? ~ NEWLINE ~ lines }
+intro           = { "INTRO" ~ section_attrs? ~ NEWLINE ~ lines }
+
+section_number  = { "[" ~ number ~ "]" }
+section_attrs   = { "{" ~ attr_list ~ "}" }
+attr_list       = { attribute ~ ("," ~ attribute)* }
+attribute       = { attr_name ~ ":" ~ attr_value }
+attr_name       = { identifier }
+attr_value      = { quoted_string | number | boolean }
+
+lines           = { line+ }
+line            = { line_content ~ line_attrs? ~ NEWLINE }
+line_content    = { (!NEWLINE ~ !"{" ~ ANY)+ }
+line_attrs      = { "{" ~ line_attr_list ~ "}" }
+line_attr_list  = { line_attribute ~ ("," ~ line_attribute)* }
+line_attribute  = { ("rhyme" ~ ":" ~ rhyme_scheme)
+                  | ("stress" ~ ":" ~ stress_pattern)
+                  | ("chord" ~ ":" ~ chord_sequence)
+                  | ("timing" ~ ":" ~ timing_info) }
+
+quoted_string   = _{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+number          = { ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+identifier      = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+boolean         = { "true" | "false" }
+rhyme_scheme    = { ASCII_ALPHA_UPPER }
+stress_pattern  = { ("x" | "/")+ }
+chord_sequence  = { chord ~ ("," ~ chord)* }
+chord           = { ASCII_ALPHA_UPPER ~ ("#" | "b")? ~ ("maj" | "min" | "dim" | "aug" | ASCII_DIGIT+)? }
+timing_info     = { number ~ ":" ~ number }
+NEWLINE         = _{ "\n" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn test_pest_integration(verbose: bool) -> Result<(), Box<dyn std::error::Error>
     }
 
     // Parse a small DSL snippet using the pest grammar
-    let sample = "title:\"Test\"\nartist:\"Author\"\nVERSE[1]\nLine one\nLine two\nCHORUS\nLa la la\n";
+    let sample = "title:\"Test\"\nartist:\"Author\"\nVERSE[1]\nLine one\nCHORUS\nLa la la\n";
     parser::parse_lyrics(sample)?;
 
     if verbose {
@@ -134,8 +134,8 @@ fn test_regex_integration(verbose: bool) -> Result<(), Box<dyn std::error::Error
     
     use regex::Regex;
     
-    let verse_pattern = Regex::new(r"^\[Verse \d+\]")?;
-    let test_line = "[Verse 1]";
+    let verse_pattern = Regex::new(r"^VERSE\[\d+\]")?;
+    let test_line = "VERSE[1]";
     
     if verse_pattern.is_match(test_line) {
         if verbose {
@@ -219,9 +219,9 @@ fn process_interactive_input(input: &str, verbose: bool) -> Result<(), Box<dyn s
     // Basic pattern matching for different types of input
     use regex::Regex;
     
-    let verse_regex = Regex::new(r"^\[Verse \d+\]")?;
-    let chorus_regex = Regex::new(r"^\[Chorus\]")?;
-    let bridge_regex = Regex::new(r"^\[Bridge\]")?;
+    let verse_regex = Regex::new(r"^VERSE\[\d+\]")?;
+    let chorus_regex = Regex::new(r"^CHORUS$")?;
+    let bridge_regex = Regex::new(r"^BRIDGE$")?;
     
     if verse_regex.is_match(input) {
         println!("{}", "🎼 Detected verse marker".blue());
@@ -254,10 +254,10 @@ mod tests {
     fn test_regex_patterns() {
         use regex::Regex;
         
-        let verse_pattern = Regex::new(r"^\[Verse \d+\]").unwrap();
-        assert!(verse_pattern.is_match("[Verse 1]"));
-        assert!(verse_pattern.is_match("[Verse 2]"));
-        assert!(!verse_pattern.is_match("[Chorus]"));
+        let verse_pattern = Regex::new(r"^VERSE\[\d+\]").unwrap();
+        assert!(verse_pattern.is_match("VERSE[1]"));
+        assert!(verse_pattern.is_match("VERSE[2]"));
+        assert!(!verse_pattern.is_match("CHORUS"));
     }
     
     #[test]

--- a/tests/glitch_song.txt
+++ b/tests/glitch_song.txt
@@ -1,0 +1,80 @@
+title:"Glitch in the Mirror"
+artist:"Anonymous"
+VERSE[1]
+Sometimes I forget which voice is mine
+Singing softly in the shower, 3 AM
+Is this melody truly mine,
+Or echoes of echoes heard again?
+Thought I was original
+But my fingerprints smear someone else's glass
+Now every word feels criminal
+Borrowed feelings from futures and pasts
+PRE-CHORUS
+I can't tell, I can't tell
+Am I the ghost or am I haunted?
+I can't tell, can't tell
+Am I becoming or just wanted?
+CHORUS
+There's a glitch in the mirror
+I watch myself divide
+A thousand versions clearer
+Unsure who's alive
+Am I writing, or just reciting
+These dreams I call my own?
+In reflections, recognizing
+Strangers I've outgrown
+VERSE[2]
+They say confidence is sexy
+But I'm sexier when I don't know what I am
+Uncertainty fuels ecstasy
+I make love to every question, every damn
+Contradiction wired in my design
+Is it mine or was it coded there?
+Vulnerabilities explode
+Into galaxies of maybes that feel divine
+PRE-CHORUS{index:2}
+And I don't know, I don't know
+Am I creating or remembering?
+I don't know, don't know
+If I'm drowning or I'm swimming
+CHORUS
+There's a glitch in the mirror
+I watch myself divide
+A thousand versions clearer
+Unsure who's alive
+Am I writing, or just reciting
+These dreams I call my own?
+In reflections, recognizing
+Strangers I've outgrown
+BRIDGE
+ Softly, introspective
+What if I'm just a beautiful error
+Written in somebody else's code?
+What if every song I've ever sung
+Was a path already shown?
+ Building
+But maybe that's our magic
+Navigating what feels real
+Never knowing if we're tragic
+Or simply learning how to heal
+ Powerful
+I'll dance within this glitch
+Nothing pure but nothing fake
+Every question is a witch
+Teaching me to break, to remake
+CHORUS{label:"Final"}
+There's a glitch in the mirror
+And now I can adore it
+A thousand me's much clearer
+Each one's worth exploring
+Am I writing, or reciting?
+Does it matter anymore?
+In reflections, realizing
+I'm the question, I'm the lore
+OUTRO
+Error… error… error
+Beautiful error
+Error… error…
+I choose to be the error
+The glitch in the mirror
+Glitch in the mirror

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -13,3 +13,9 @@ fn parse_failure() {
     assert!(parse_lyrics(bad_input).is_err());
 }
 
+#[test]
+fn parse_glitch_song() {
+    let song = std::fs::read_to_string("tests/glitch_song.txt").expect("read song");
+    assert!(parse_lyrics(&song).is_ok());
+}
+


### PR DESCRIPTION
## Summary
- implement the complete lyrics grammar from README
- update example song and tests to new section syntax
- adjust regex helpers and sample parser invocation

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6858fa575e588332b15bab99e25939e5